### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal.

## Changes
- Added GitHub Skills to the activities list in `src/app.py`
- Part of the GitHub Certifications program to help with college applications
- Scheduled for Wednesdays, 3:30 PM - 5:00 PM
- Capacity for 25 students
- Ready for student registrations

## Resolves
Closes #6

## Context
Students reported that the GitHub Skills activity announced in the school assembly was missing from the signup page. This was time-sensitive as registrations close by the end of this week.